### PR TITLE
Feature: To be able to choose where to save the screener data

### DIFF
--- a/finviz/screener.py
+++ b/finviz/screener.py
@@ -131,15 +131,24 @@ class Screener(object):
 
     get = __getitem__
 
-    def to_sqlite(self):
-        """ Exports the generated table into a SQLite database, located in the user's current directory. """
+    def to_sqlite(self, filename):
+        """ Exports the generated table into a SQLite database.
 
-        export_to_db(self.headers, self.data)
+        :param filename: SQLite database file path
+        :type filename: str
+        """
 
-    def to_csv(self):
-        """ Exports the generated table into a CSV file, located in the user's current directory. """
+        export_to_db(self.headers, self.data, filename)
 
-        export_to_csv(self.headers, self.data)
+    def to_csv(self, filename=None):
+        """ Exports the generated table into a CSV file.
+        Returns a CSV string if filename is None.
+
+        :param filename: CSV file path
+        :type filename: str
+        """
+
+        return export_to_csv(self.headers, self.data, filename)
 
     def get_charts(self, period='d', size='l', chart_type='c', ta='1'):
         """


### PR DESCRIPTION
It is more flexible to be able to choose where to save the screener data.

Here is an example:
Setup:
```python
from finviz.screener import Screener
filters = ['exch_nasd', 'idx_sp500']
stock_list = Screener(filters=filters, order='price')
```

Now:
```python
stock_list.to_csv() # saves to screener_results.csv
stock_list.to_sqlite() # saves to ../screener.sqlite
```

Feature:
```python
csv_string = stock_list.to_csv(filename=None) # return csv string
stock_list.to_csv(filename="other_name.csv") # saves to other_name.csv
stock_list.to_sqlite(filename="other_name.sqlite") # saves to other_name.sqlite
stock_list.to_sqlite() # Error: Filename is mandatory
```