### PR TITLE
get_analyst_price_targets() .. added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,10 @@ Individual stocks
     [{'Insider Trading': 'KONDO CHRIS', 'Relationship': 'Principal Accounting Officer', 'Date': 'Nov 19', 'Transaction':            'Sale', 'Cost': '190.00', '#Shares': '3,408', 'Value ($)': '647,520', '#Shares Total': '8,940', 'SEC Form 4': 'Nov 21           06:31 PM'},...
     >>> finviz.get_news('AAPL')
     [('Chinas Economy Slows to the Weakest Pace Since 2009', 'https://finance.yahoo.com/news/china-economy-slows-weakest-pace-      020040147.html'),...
-    
+    >>>
+    >>> finviz.get_analyst_price_targets('AAPL')
+    [{'date': '2019-10-24', 'category': 'Reiterated', 'analyst': 'UBS', 'rating': 'Buy', 'price_from': 235, 'price_to': 275}, ...
+
 Downloading charts
 =====
 


### PR DESCRIPTION
I found this finviz package as a wonderful one for extracting the Ticker Data. So added this additional functionality and tested the code. Please accept this PR.

This pull request is to add get_analyst_price_targets() function to  main_func.py file .
This function extracts all the "Analysts ratings & Price targets" for a given Ticker as this DATA is presented on FINVIZ webpage in a tabular format.

