### PR TITLE
Fix handling of Nonetype exception in to_csv function

### DIFF
--- a/finviz/screener.py
+++ b/finviz/screener.py
@@ -208,7 +208,7 @@ class Screener(object):
         :type filename: str
         """
 
-        if filename.endswith('.csv'):
+        if filename and filename.endswith('.csv'):
             filename = filename[:-4]
 
         if len(self.analysis) > 0:


### PR DESCRIPTION
Currently when to_csv function is executed, it fails with Nonetype exception for missing filename.
To fix this issue, i added a check that if filename exists then only filename specific operations.

Signed-off-by: Ray Mogg <itsraymoss@gmail.com>