### PR TITLE
Removed the unnecessary print of cool variable

### DIFF
--- a/finviz/helper_functions/request_functions.py
+++ b/finviz/helper_functions/request_functions.py
@@ -30,7 +30,6 @@ def http_request_get(url, session=None, payload=None, parse=True):
             content = requests.get(url, params=payload, verify=False, headers={'User-Agent': generate_user_agent()})
 
         content.raise_for_status()  # Raise HTTPError for bad requests (4xx or 5xx)
-
         if parse:
             return html.fromstring(content.text), content.url
         else:
@@ -48,9 +47,7 @@ def sequential_data_scrape(scrape_func: Callable, urls: List[str], delay: float 
             if response.text == "Too many requests.":
                 raise TooManyRequests(f"URL: {url}, Response HTML: {response.text}")
             kwargs["URL"] = url
-            cool = scrape_func(response.text, *args, **kwargs)
-            # print(cool)
-            data.append(cool)
+            data.append(scrape_func(response.text, *args, **kwargs))
             time.sleep(delay)
         except Exception as exc:
             raise exc

--- a/finviz/helper_functions/request_functions.py
+++ b/finviz/helper_functions/request_functions.py
@@ -49,7 +49,7 @@ def sequential_data_scrape(scrape_func: Callable, urls: List[str], delay: float 
                 raise TooManyRequests(f"URL: {url}, Response HTML: {response.text}")
             kwargs["URL"] = url
             cool = scrape_func(response.text, *args, **kwargs)
-            print(cool)
+            # print(cool)
             data.append(cool)
             time.sleep(delay)
         except Exception as exc:


### PR DESCRIPTION
When creating a new Screener object, a helper functions prints the result as a dictionary. This commit removes the unnecessary print of a variable.