### PR TITLE
Need to set event loop in run_connector

### DIFF
--- a/finviz/helper_functions/request_functions.py
+++ b/finviz/helper_functions/request_functions.py
@@ -97,6 +97,7 @@ class Connector:
     def run_connector(self):
         """ Starts the asynchronous loop and returns the scraped data. """
 
+        asyncio.set_event_loop(asyncio.SelectorEventLoop())
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.__async_scraper())
 


### PR DESCRIPTION
When calling screener from flasks, or other multi threaded environment,
there's no event loop thread.

Fixes #85