### PR TITLE
Solved issue #99 example.py not working

### DIFF
--- a/finviz/helper_functions/scraper_functions.py
+++ b/finviz/helper_functions/scraper_functions.py
@@ -8,7 +8,10 @@ from lxml import etree, html
 
 def get_table(page_html: requests.Response, headers, rows=None, **kwargs):
     """ Private function used to return table data inside a list of dictionaries. """
-    page_parsed = html.fromstring(page_html.content)
+    if isinstance(page_html, str):
+        page_parsed = html.fromstring(page_html)
+    else:
+        page_parsed = html.fromstring(page_html.text)
     # When we call this method from Portfolio we don't fill the rows argument.
     # Conversely, we always fill the rows argument when we call this method from Screener.
     # Also, in the portfolio page, we don't need the last row - it's redundant.


### PR DESCRIPTION
portfolio.py and screener.py both used scraper_function.py get_table(), but with different arguments.

portfolio.py passed response text string as page_html, while screener.py passed response object as page_html. 