### PR TITLE
TTL Cache

### DIFF
--- a/finviz/main_func.py
+++ b/finviz/main_func.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from lxml import etree
+from cachetools import TTLCache
 
 from finviz.helper_functions.request_functions import http_request_get
 from finviz.helper_functions.scraper_functions import get_table
@@ -8,7 +9,7 @@ from finviz.helper_functions.scraper_functions import get_table
 STOCK_URL = "https://finviz.com/quote.ashx"
 NEWS_URL = "https://finviz.com/news.ashx"
 CRYPTO_URL = "https://finviz.com/crypto_performance.ashx"
-STOCK_PAGE = {}
+STOCK_PAGE = TTLCache(maxsize=100, ttl=60*15)
 
 
 def get_page(ticker):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ user_agent~=0.1.9
 cssselect~=1.1.0
 tqdm~=4.61.1
 tenacity~=7.0.0
+cachetools~=5.0.0


### PR DESCRIPTION
Either create a TTL Cache for STOCK_PAGE, or do not use a global dict. This creates a memory issue that can easily be avoided. As the code exists right now, storing pages in global var provides no benefit.