### PR TITLE
[Hotfix] Adapt to New Stock Page Header DOM Structure

### DIFF
--- a/finviz/main_func.py
+++ b/finviz/main_func.py
@@ -34,7 +34,7 @@ def get_stock(ticker):
 
     title = page_parsed.cssselect('div[class="fv-container py-2.5"]')[0]
     data = {}
-    data["Ticker"] = title.cssselect('h1[class="quote-header_ticker-wrapper_ticker"]')[0].text_content()
+    data["Ticker"] = title.cssselect('h1[class="quote-header_ticker-wrapper_ticker"]')[0].text_content().strip()
     company_details = title.cssselect('h2[class="quote-header_ticker-wrapper_company"]')[0]
     data["Company"] = company_details.text_content().strip()
     company_link = company_details.cssselect('a[class="tab-link block truncate"]')[0].attrib["href"]

--- a/finviz/main_func.py
+++ b/finviz/main_func.py
@@ -32,13 +32,16 @@ def get_stock(ticker):
     get_page(ticker)
     page_parsed = STOCK_PAGE[ticker]
 
-    title = page_parsed.cssselect('table[class="fullview-title"]')[0]
-    keys = ["Ticker","Company", "Sector", "Industry", "Country"]
-    fields = [f.text_content() for f in title.cssselect('a[class="tab-link"]')]
-    data = dict(zip(keys, fields))
-
-    company_link = title.cssselect('a[class="tab-link"]')[0].attrib["href"]
+    title = page_parsed.cssselect('div[class="fv-container py-2.5"]')[0]
+    data = {}
+    data["Ticker"] = title.cssselect('h1[class="quote-header_ticker-wrapper_ticker"]')[0].text_content()
+    company_details = title.cssselect('h2[class="quote-header_ticker-wrapper_company"]')[0]
+    data["Company"] = company_details.text_content().strip()
+    company_link = company_details.cssselect('a[class="tab-link block truncate"]')[0].attrib["href"]
     data["Website"] = company_link if company_link.startswith("http") else None
+    keys = ["Sector", "Industry", "Country", "Exchange"]
+    fields = [f.text_content() for f in title.cssselect('a[class="tab-link"]')]
+    data.update(dict(zip(keys, fields)))
 
     all_rows = [
         row.xpath("td//text()")


### PR DESCRIPTION
This pull request addresses the issue where the `get_stock()` function is failing due to a change in the DOM structure of the stock page header on the Finviz website. To resolve this problem, I have implemented a hotfix that adjusts the crawler's code to accommodate the updated header structure. This ensures the continued functionality of the Finviz crawler for retrieving stock data.