### PR TITLE
fix: get_crypto breaking change; add test

### DIFF
--- a/finviz/main_func.py
+++ b/finviz/main_func.py
@@ -298,16 +298,26 @@ def get_all_news():
 def get_crypto(pair):
     """
 
-    :param pair: crypto pair
+    :param pair: crypto pair symbol (e.g. "ETHUSD"), case-insensitive; or row index (int)
     :return: dictionary
     """
 
     page_parsed, _ = http_request_get(url=CRYPTO_URL, parse=True)
     page_html, _ = http_request_get(url=CRYPTO_URL, parse=False)
-    crypto_headers = page_parsed.cssselect('tr[valign="middle"]')[0].xpath("td//text()")
+    header_row = page_parsed.cssselect('tr[valign="middle"]')[0]
+    crypto_headers = [t.strip() for t in header_row.xpath(".//th//text()") if t.strip()]
+    if not crypto_headers:
+        crypto_headers = [t.strip() for t in header_row.xpath(".//td//text()") if t.strip()]
     crypto_table_data = get_table(page_html, crypto_headers)
 
-    return crypto_table_data[pair]
+    if isinstance(pair, int):
+        return crypto_table_data[pair]
+
+    key = str(pair).strip().upper()
+    for row in crypto_table_data:
+        if row.get("Ticker", "").strip().upper() == key:
+            return row
+    raise KeyError(f"Crypto pair not found: {pair!r}")
 
 
 def get_analyst_price_targets(ticker, last_ratings=5):

--- a/finviz/tests/test_crypto.py
+++ b/finviz/tests/test_crypto.py
@@ -1,0 +1,19 @@
+"""Tests for get_crypto (live Finviz crypto performance table)."""
+
+import pytest
+
+from finviz.main_func import get_crypto
+
+
+class TestGetCrypto:
+    @pytest.mark.network
+    def test_ethusd(self):
+        row = get_crypto("ethusd")
+        assert row["Ticker"] == "ETHUSD"
+        assert float(row["Price"]) > 0
+        assert "Perf Day" in row
+
+    @pytest.mark.network
+    def test_unknown_pair(self):
+        with pytest.raises(KeyError, match="not found"):
+            get_crypto("NOTAREALPAIR999")


### PR DESCRIPTION
**Problem**  
`get_crypto("ETHUSD")` failed with `TypeError: list indices must be integers or slices, not str`. The crypto table headers use `<th>`, but the parser only read `<td>`, so headers were empty, `get_table()` produced empty row dicts, and the code still treated `pair` as a list index.

**Change**  
- Parse headers from `.//th//text()` (fallback to `td` if needed).  
- Resolve string `pair` by matching the `Ticker` column case-insensitively.  
- Keep `int` `pair` as a row index.  
- Raise `KeyError` for unknown symbols.

**Tests**  
Add `finviz/tests/test_crypto.py`: live `ethusd` row smoke test and unknown-pair error test (`@pytest.mark.network`).